### PR TITLE
[SCD-25] drop datetime columns and create time columns

### DIFF
--- a/migrations/Version20201217095449.php
+++ b/migrations/Version20201217095449.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201217095449 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Change datetime to time where its necessary';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $schema->getTable('running')
+            ->dropColumn('started_at')
+            ->addColumn('started_at', 'time', ['notnull' => false]);
+
+        $schema->getTable('sleeping')
+            ->dropColumn('awake_at')
+            ->addColumn('awake_at', 'time', ['notnull' => false]);
+
+        $schema->getTable('sleeping')
+            ->dropColumn('sleep_at')
+            ->addColumn('sleep_at', 'time', ['notnull' => false]);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $schema->getTable('running')
+            ->dropColumn('started_at')
+            ->addColumn('started_at', 'datetime', ['notnull' => false]);
+
+        $schema->getTable('sleeping')
+            ->dropColumn('awake_at')
+            ->addColumn('awake_at', 'datetime', ['notnull' => false]);
+
+        $schema->getTable('sleeping')
+            ->dropColumn('sleep_at')
+            ->addColumn('sleep_at', 'datetime', ['notnull' => false]);
+    }
+}

--- a/src/Entity/Running.php
+++ b/src/Entity/Running.php
@@ -54,7 +54,7 @@ class Running
     private ?int $waterTemperatureCelsius;
 
     /**
-     * @ORM\Column(type="datetime", nullable=true)
+     * @ORM\Column(type="time", nullable=true)
      */
     private ?DateTimeInterface $startedAt;
 

--- a/src/Entity/Sleeping.php
+++ b/src/Entity/Sleeping.php
@@ -19,12 +19,12 @@ class Sleeping
     private Diary $diary;
 
     /**
-     * @ORM\Column(type="datetime", nullable=true)
+     * @ORM\Column(type="time", nullable=true)
      */
     private ?DateTimeInterface $awakeAt;
 
     /**
-     * @ORM\Column(type="datetime", nullable=true)
+     * @ORM\Column(type="time", nullable=true)
      */
     private ?DateTimeInterface $sleepAt;
 


### PR DESCRIPTION
1. Удаляет колонки `running.started_at`, `sleeping.awake_at`, `sleeping.sleep_at`
2. Создает эти же колонки, но с типом `time`

resolves #25 