### PR TITLE
[SCD-77] тест POST /api/diary

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  database:
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_USER: self-control-diary
+      POSTGRES_PASSWORD: self-control-diary
+      POSTGRES_DB: self-control-diary
+    ports:
+    - 5443:5432

--- a/src/Controller/Diary/DiaryDTO.php
+++ b/src/Controller/Diary/DiaryDTO.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace App\Controller\Diary;
 
+use App\SelfValidationInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class DiaryDTO
+final class DiaryDTO implements SelfValidationInterface
 {
     /**
      * @Assert\AtLeastOneOf({
@@ -14,7 +15,7 @@ final class DiaryDTO
      *     @Assert\IsNull
      * })
      */
-    public ?string $notes = null;
+    public ?string $notes;
 
     /**
      * @Assert\Date
@@ -22,4 +23,15 @@ final class DiaryDTO
      * @Assert\NotBlank
      */
     public string $notedAt;
+
+    public function validate(): array
+    {
+        if (!array_key_exists('notes', get_object_vars($this))) {
+            return [
+                'notes' => 'property should exists',
+            ];
+        }
+
+        return [];
+    }
 }

--- a/src/Controller/Diary/DiaryDTO.php
+++ b/src/Controller/Diary/DiaryDTO.php
@@ -9,9 +9,12 @@ use Symfony\Component\Validator\Constraints as Assert;
 final class DiaryDTO
 {
     /**
-     * @Assert\NotBlank
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Length(min=1),
+     *     @Assert\IsNull
+     * })
      */
-    public ?string $notes;
+    public ?string $notes = null;
 
     /**
      * @Assert\Date

--- a/src/Controller/Diary/PostDiary/Controller.php
+++ b/src/Controller/Diary/PostDiary/Controller.php
@@ -37,6 +37,6 @@ class Controller extends AbstractController
             );
         }
 
-        return $this->json($createdDiary, Response::HTTP_OK, [], ['groups' => 'api']);
+        return $this->json($createdDiary, Response::HTTP_CREATED, [], ['groups' => 'api']);
     }
 }

--- a/src/Controller/Diary/PostDiary/Controller.php
+++ b/src/Controller/Diary/PostDiary/Controller.php
@@ -6,6 +6,7 @@ namespace App\Controller\Diary\PostDiary;
 
 use App\Controller\Diary\DiaryDTO;
 use App\Service\Diary\DiaryService;
+use App\Service\Diary\Exception\DiaryAlreadyExistsException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -24,10 +25,18 @@ class Controller extends AbstractController
      */
     public function postDiary(DiaryDTO $diaryDto): Response
     {
-        $createdDiary = $this->diaryService->persistFromDto($diaryDto);
+        try {
+            $createdDiary = $this->diaryService->persistFromDto($diaryDto);
+        } catch (DiaryAlreadyExistsException $e) {
+            return $this->json(
+                [
+                    'code' => Response::HTTP_CONFLICT,
+                    'message' => 'Diary already exists',
+                ],
+                Response::HTTP_CONFLICT
+            );
+        }
 
-        return null === $createdDiary
-            ? new Response('', Response::HTTP_CONFLICT)
-            : $this->json($createdDiary, Response::HTTP_CREATED, [], ['groups' => 'api']);
+        return $this->json($createdDiary, Response::HTTP_OK, [], ['groups' => 'api']);
     }
 }

--- a/src/Exception/HttpRequestSelfValidationException.php
+++ b/src/Exception/HttpRequestSelfValidationException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+final class HttpRequestSelfValidationException extends BadRequestHttpException
+{
+    public function __construct(array $violations, \Exception $previous = null)
+    {
+        parent::__construct(
+            'Self validation errors: ' . $this->violationsToString($violations),
+            $previous,
+            Response::HTTP_BAD_REQUEST
+        );
+    }
+
+    private function violationsToString(array $violations): string
+    {
+        return substr(array_reduce(
+            array_keys($violations),
+            fn ($carry, $property): string => sprintf(
+                $carry . '"%s" - %s, ',
+                $property,
+                $violations[$property]
+            ),
+            ''
+        ), 0, -2);
+    }
+}

--- a/src/SelfValidationInterface.php
+++ b/src/SelfValidationInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+interface SelfValidationInterface
+{
+    public function validate(): array;
+}

--- a/src/Service/Diary/Exception/DiaryAlreadyExistsException.php
+++ b/src/Service/Diary/Exception/DiaryAlreadyExistsException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Diary\Exception;
+
+final class DiaryAlreadyExistsException extends \Exception
+{
+}

--- a/tests/Api/ApiDiaryDeleteCest.php
+++ b/tests/Api/ApiDiaryDeleteCest.php
@@ -12,7 +12,6 @@ use App\Entity\Sleeping;
 use App\Entity\User;
 use App\Tests\ApiTester;
 use Codeception\Util\HttpCode;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class ApiDiaryDeleteCest
 {
@@ -23,12 +22,7 @@ class ApiDiaryDeleteCest
         $mantraBuddhaShakyamuni = new MenchoMantra('Будда Шакьямуни', 1);
         $I->haveInRepository($mantraBuddhaShakyamuni);
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $diary = new Diary($user, new \DateTimeImmutable('2021-01-30'));
@@ -70,12 +64,7 @@ class ApiDiaryDeleteCest
     {
         $I->wantToTest('DELETE /api/diary/{noted_at} (diary not found)');
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $I->haveHttpHeader('Content-Type', 'application/json');

--- a/tests/Api/ApiDiaryGetCest.php
+++ b/tests/Api/ApiDiaryGetCest.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Api;
 
 use App\Entity\Diary;
-use App\Entity\User;
 use App\Tests\ApiTester;
 use Codeception\Util\HttpCode;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class ApiDiaryGetCest
 {
@@ -16,12 +14,7 @@ class ApiDiaryGetCest
 
     public function _before(ApiTester $I): void
     {
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $this->diary = new Diary($user, new \DateTimeImmutable('2021-02-04'));

--- a/tests/Api/ApiDiaryPostCest.php
+++ b/tests/Api/ApiDiaryPostCest.php
@@ -33,11 +33,13 @@ class ApiDiaryPostCest
             'notes' => 'My diary note',
         ]);
 
-        $I->seeResponseCodeIs(HttpCode::OK);
-        $I->seeResponseJsonMatchesJsonPath('$.uuid');
-        $I->seeResponseJsonMatchesJsonPath('$.notes');
-        $I->seeResponseJsonMatchesJsonPath('$.notedAt');
-
+        $I->seeResponseCodeIs(HttpCode::CREATED);
+        $I->seeResponseIsJson();
+        $I->seeResponseMatchesJsonType([
+            'uuid' => 'string',
+            'notes' => 'string|null',
+            'notedAt' => 'string:date',
+        ]);
         $I->seeResponseContainsJson([
             'notes' => 'My diary note',
             'notedAt' => '2021-02-21T00:00:00+00:00',
@@ -55,6 +57,138 @@ class ApiDiaryPostCest
         $I->assertEquals($actualDiaryUuid, $diaryInRepository->getUuid());
         $I->assertEquals('My diary note', $diaryInRepository->getNotes());
         $I->assertEquals(new \DateTimeImmutable('2021-02-21'), $diaryInRepository->getNotedAt());
+    }
+
+    public function testMissedNotesSuccess(ApiTester $I): void
+    {
+        $I->wantToTest('POST /api/diary success with missed notes');
+
+        $user = $I->createUser();
+        $I->haveInRepository($user);
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/api/login', [
+            'username' => 'user@example.com',
+            'password' => 'my-strong-password',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseJsonMatchesJsonPath('$.token');
+        $token = $I->grabDataFromResponseByJsonPath('$.token')[0];
+
+        $I->amBearerAuthenticated($token);
+        $I->sendPOST('/api/diary', [
+            'notedAt' => '2021-02-21',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::CREATED);
+        $I->seeResponseIsJson();
+        $I->seeResponseMatchesJsonType([
+            'uuid' => 'string',
+            'notes' => 'string|null',
+            'notedAt' => 'string:date',
+        ]);
+        $I->seeResponseContainsJson([
+            'notedAt' => '2021-02-21T00:00:00+00:00',
+            'notes' => null,
+        ]);
+
+        $actualDiaryUuid = $I->grabDataFromResponseByJsonPath('$.uuid')[0];
+        $I->seeInRepository(Diary::class, ['uuid' => $actualDiaryUuid]);
+
+        /** @var Diary $diaryInRepository */
+        $diaryInRepository = $I->grabEntitiesFromRepository(
+            Diary::class,
+            ['uuid' => $actualDiaryUuid]
+        )[0];
+
+        $I->assertEquals($actualDiaryUuid, $diaryInRepository->getUuid());
+        $I->assertNull($diaryInRepository->getNotes());
+        $I->assertEquals(new \DateTimeImmutable('2021-02-21'), $diaryInRepository->getNotedAt());
+    }
+
+    public function testNullNotesSuccess(ApiTester $I): void
+    {
+        $I->wantToTest('POST /api/diary success with null notes');
+
+        $user = $I->createUser();
+        $I->haveInRepository($user);
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/api/login', [
+            'username' => 'user@example.com',
+            'password' => 'my-strong-password',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseJsonMatchesJsonPath('$.token');
+        $token = $I->grabDataFromResponseByJsonPath('$.token')[0];
+
+        $I->amBearerAuthenticated($token);
+        $I->sendPOST('/api/diary', [
+            'notedAt' => '2021-02-21',
+            'notes' => null,
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::CREATED);
+        $I->seeResponseIsJson();
+        $I->seeResponseMatchesJsonType([
+            'uuid' => 'string',
+            'notes' => 'string|null',
+            'notedAt' => 'string:date',
+        ]);
+        $I->seeResponseContainsJson([
+            'notedAt' => '2021-02-21T00:00:00+00:00',
+            'notes' => null,
+        ]);
+
+        $actualDiaryUuid = $I->grabDataFromResponseByJsonPath('$.uuid')[0];
+        $I->seeInRepository(Diary::class, ['uuid' => $actualDiaryUuid]);
+
+        /** @var Diary $diaryInRepository */
+        $diaryInRepository = $I->grabEntitiesFromRepository(
+            Diary::class,
+            ['uuid' => $actualDiaryUuid]
+        )[0];
+
+        $I->assertEquals($actualDiaryUuid, $diaryInRepository->getUuid());
+        $I->assertNull($diaryInRepository->getNotes());
+        $I->assertEquals(new \DateTimeImmutable('2021-02-21'), $diaryInRepository->getNotedAt());
+    }
+
+    public function testBlankNotesSuccess(ApiTester $I): void
+    {
+        $I->wantToTest('POST /api/diary success with blank notes');
+
+        $user = $I->createUser();
+        $I->haveInRepository($user);
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/api/login', [
+            'username' => 'user@example.com',
+            'password' => 'my-strong-password',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseJsonMatchesJsonPath('$.token');
+        $token = $I->grabDataFromResponseByJsonPath('$.token')[0];
+
+        $I->amBearerAuthenticated($token);
+        $I->sendPOST('/api/diary', [
+            'notedAt' => '2021-02-21',
+            'notes' => '',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::BAD_REQUEST);
+        $I->seeResponseIsJson();
+        $I->seeResponseMatchesJsonType([
+            'code' => 'integer',
+            'message' => 'string',
+        ]);
+        $I->seeResponseContainsJson([
+            'code' => HttpCode::BAD_REQUEST,
+            'message' => 'Validation errors: "notes" - This value should satisfy at least one of the following constraints: [1] This value is too short. It should have 1 character or more. [2] This value should be null.',
+        ]);
     }
 
     public function testConflictPost(ApiTester $I): void
@@ -123,7 +257,7 @@ class ApiDiaryPostCest
         $I->seeResponseCodeIs(HttpCode::BAD_REQUEST);
         $I->seeResponseContainsJson([
             'code' => HttpCode::BAD_REQUEST,
-            'message' => 'Validation errors: "notes" - This value should not be blank., "notedAt" - This value should not be null., "notedAt" - This value should not be blank.',
+            'message' => 'Validation errors: "notedAt" - This value should not be null., "notedAt" - This value should not be blank.',
         ]);
     }
 }

--- a/tests/Api/ApiDiaryPostCest.php
+++ b/tests/Api/ApiDiaryPostCest.php
@@ -89,4 +89,14 @@ class ApiDiaryPostCest
             'message' => 'Diary already exists',
         ]);
     }
+
+    public function testNotAuthorized(ApiTester $I): void
+    {
+        $I->wantToTest('POST /api/diary unauthorized');
+        $I->sendPOST('/api/diary', [
+            'notedAt' => '2021-02-21',
+            'notes' => 'My diary note',
+        ]);
+        $I->seeResponseCodeIs(HttpCode::UNAUTHORIZED);
+    }
 }

--- a/tests/Api/ApiDiaryPostCest.php
+++ b/tests/Api/ApiDiaryPostCest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\Diary;
+use App\Tests\ApiTester;
+use Codeception\Util\HttpCode;
+
+class ApiDiaryPostCest
+{
+    public function testSuccessPost(ApiTester $I): void
+    {
+        $I->wantToTest('POST /api/diary success');
+
+        $user = $I->createUser();
+        $I->haveInRepository($user);
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/api/login', [
+            'username' => 'user@example.com',
+            'password' => 'my-strong-password',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseJsonMatchesJsonPath('$.token');
+        $token = $I->grabDataFromResponseByJsonPath('$.token')[0];
+
+        $I->amBearerAuthenticated($token);
+        $I->sendPOST('/api/diary', [
+            'notedAt' => '2021-02-21',
+            'notes' => 'My diary note',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseJsonMatchesJsonPath('$.uuid');
+        $I->seeResponseJsonMatchesJsonPath('$.notes');
+        $I->seeResponseJsonMatchesJsonPath('$.notedAt');
+
+        $I->seeResponseContainsJson([
+            'notes' => 'My diary note',
+            'notedAt' => '2021-02-21T00:00:00+00:00',
+        ]);
+
+        $actualDiaryUuid = $I->grabDataFromResponseByJsonPath('$.uuid')[0];
+        $I->seeInRepository(Diary::class, ['uuid' => $actualDiaryUuid]);
+
+        /** @var Diary $diaryInRepository */
+        $diaryInRepository = $I->grabEntitiesFromRepository(
+            Diary::class,
+            ['uuid' => $actualDiaryUuid]
+        )[0];
+
+        $I->assertEquals($actualDiaryUuid, $diaryInRepository->getUuid());
+        $I->assertEquals('My diary note', $diaryInRepository->getNotes());
+        $I->assertEquals(new \DateTimeImmutable('2021-02-21'), $diaryInRepository->getNotedAt());
+    }
+
+    public function testConflictPost(ApiTester $I): void
+    {
+        $I->wantToTest('POST /api/diary conflict');
+
+        $user = $I->createUser();
+        $I->haveInRepository($user);
+
+        $diary = new Diary($user, new \DateTimeImmutable('2021-02-21'));
+        $I->haveInRepository($diary);
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/api/login', [
+            'username' => 'user@example.com',
+            'password' => 'my-strong-password',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseJsonMatchesJsonPath('$.token');
+        $token = $I->grabDataFromResponseByJsonPath('$.token')[0];
+
+        $I->amBearerAuthenticated($token);
+        $I->sendPOST('/api/diary', [
+            'notedAt' => '2021-02-21',
+            'notes' => 'My diary note',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::CONFLICT);
+        $I->seeResponseContainsJson([
+            'code' => HttpCode::CONFLICT,
+            'message' => 'Diary already exists',
+        ]);
+    }
+}

--- a/tests/Api/ApiDiaryPostCest.php
+++ b/tests/Api/ApiDiaryPostCest.php
@@ -99,4 +99,31 @@ class ApiDiaryPostCest
         ]);
         $I->seeResponseCodeIs(HttpCode::UNAUTHORIZED);
     }
+
+    public function testBadRequest(ApiTester $I): void
+    {
+        $I->wantToTest('POST /api/diary bad request');
+
+        $user = $I->createUser();
+        $I->haveInRepository($user);
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/api/login', [
+            'username' => 'user@example.com',
+            'password' => 'my-strong-password',
+        ]);
+
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseJsonMatchesJsonPath('$.token');
+        $token = $I->grabDataFromResponseByJsonPath('$.token')[0];
+
+        $I->amBearerAuthenticated($token);
+        $I->sendPOST('/api/diary');
+
+        $I->seeResponseCodeIs(HttpCode::BAD_REQUEST);
+        $I->seeResponseContainsJson([
+            'code' => HttpCode::BAD_REQUEST,
+            'message' => 'Validation errors: "notes" - This value should not be blank., "notedAt" - This value should not be null., "notedAt" - This value should not be blank.',
+        ]);
+    }
 }

--- a/tests/Api/ApiLoginPostCest.php
+++ b/tests/Api/ApiLoginPostCest.php
@@ -5,21 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Api;
 
 use App\Entity\MenchoMantra;
-use App\Entity\User;
 use App\Tests\ApiTester;
 use Codeception\Util\HttpCode;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 final class ApiLoginPostCest
 {
     public function _before(ApiTester $I): void
     {
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
     }
 

--- a/tests/Api/ApiMenchoSamayaDeleteCest.php
+++ b/tests/Api/ApiMenchoSamayaDeleteCest.php
@@ -7,10 +7,8 @@ namespace App\Tests\Api;
 use App\Entity\Diary;
 use App\Entity\MenchoMantra;
 use App\Entity\MenchoSamaya;
-use App\Entity\User;
 use App\Tests\ApiTester;
 use Codeception\Util\HttpCode;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class ApiMenchoSamayaDeleteCest
 {
@@ -23,12 +21,7 @@ class ApiMenchoSamayaDeleteCest
         $mantraChenrezig = new MenchoMantra('Ченрезиг', 1);
         $I->haveInRepository($mantraChenrezig);
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $diary = new Diary($user, new \DateTimeImmutable('2021-02-18'));
@@ -62,12 +55,7 @@ class ApiMenchoSamayaDeleteCest
         $mantraBuddhaShakyamuni = new MenchoMantra('Будда Шакьямуни', 1);
         $I->haveInRepository($mantraBuddhaShakyamuni);
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $I->haveHttpHeader('Content-Type', 'application/json');

--- a/tests/Api/ApiMenchoSamayaPatchCest.php
+++ b/tests/Api/ApiMenchoSamayaPatchCest.php
@@ -7,10 +7,8 @@ namespace App\Tests\Api;
 use App\Entity\Diary;
 use App\Entity\MenchoMantra;
 use App\Entity\MenchoSamaya;
-use App\Entity\User;
 use App\Tests\ApiTester;
 use Codeception\Util\HttpCode;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class ApiMenchoSamayaPatchCest
 {
@@ -18,12 +16,7 @@ class ApiMenchoSamayaPatchCest
     {
         $I->wantToTest('PATCH /api/mencho/samaya success');
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $mantraBuddhaShakyamuni = new MenchoMantra('Будда Шакьямуни', 1);

--- a/tests/Api/ApiMenchoSamayaPostCest.php
+++ b/tests/Api/ApiMenchoSamayaPostCest.php
@@ -7,10 +7,8 @@ namespace App\Tests\Api;
 use App\Entity\Diary;
 use App\Entity\MenchoMantra;
 use App\Entity\MenchoSamaya;
-use App\Entity\User;
 use App\Tests\ApiTester;
 use Codeception\Util\HttpCode;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class ApiMenchoSamayaPostCest
 {
@@ -21,12 +19,7 @@ class ApiMenchoSamayaPostCest
         $mantraBuddhaShakyamuni = new MenchoMantra('Будда Шакьямуни', 1);
         $I->haveInRepository($mantraBuddhaShakyamuni);
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $diary = new Diary($user, new \DateTimeImmutable('2021-02-04'));
@@ -81,12 +74,7 @@ class ApiMenchoSamayaPostCest
         $mantraBuddhaShakyamuni = new MenchoMantra('Будда Шакьямуни', 1);
         $I->haveInRepository($mantraBuddhaShakyamuni);
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $diary = new Diary($user, new \DateTimeImmutable('2021-02-05'));
@@ -126,12 +114,7 @@ class ApiMenchoSamayaPostCest
         $mantraBuddhaShakyamuni = new MenchoMantra('Будда Шакьямуни', 1);
         $I->haveInRepository($mantraBuddhaShakyamuni);
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $I->haveHttpHeader('Content-Type', 'application/json');
@@ -163,12 +146,7 @@ class ApiMenchoSamayaPostCest
     {
         $I->wantToTest('POST /api/mencho/samaya mantra not found');
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $diary = new Diary($user, new \DateTimeImmutable('2021-02-04'));
@@ -202,12 +180,7 @@ class ApiMenchoSamayaPostCest
     {
         $I->wantToTest('POST /api/mencho/samaya mantra uuid invalid');
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $diary = new Diary($user, new \DateTimeImmutable('2021-02-04'));
@@ -241,12 +214,7 @@ class ApiMenchoSamayaPostCest
     {
         $I->wantToTest('POST /api/mencho/samaya data validation failed');
 
-        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
-        $userPasswordEncoder = $I->grabService('security.password_encoder');
-        $user = new User('user@example.com');
-        $user->setPassword(
-            $userPasswordEncoder->encodePassword($user, 'my-strong-password')
-        );
+        $user = $I->createUser();
         $I->haveInRepository($user);
 
         $diary = new Diary($user, new \DateTimeImmutable('2021-02-04'));

--- a/tests/_build/support/Helper/Api.php
+++ b/tests/_build/support/Helper/Api.php
@@ -4,8 +4,25 @@ declare(strict_types=1);
 
 namespace App\Tests\Helper;
 
+use App\Entity\User;
 use Codeception\Module;
+use Codeception\Module\Symfony;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class Api extends Module
 {
+    public function createUser($username = 'user@example.com', $password = 'my-strong-password'): User
+    {
+        /** @var Symfony $symfony */
+        $symfony = $this->getModule('Symfony');
+
+        /** @var UserPasswordEncoderInterface $userPasswordEncoder */
+        $userPasswordEncoder = $symfony->grabService('security.password_encoder');
+        $user = new User($username);
+        $user->setPassword(
+            $userPasswordEncoder->encodePassword($user, $password)
+        );
+
+        return $user;
+    }
 }


### PR DESCRIPTION
1. Функциональные тесты на `POST /api/diary` (позитивный сценарий, конфликт, ошибка в теле запросе, неавторизированные запуск)
1. Добавлен хэлпер `$I->createUser()` который создают пользователя с заданным логином и паролем. Эта функция вызывается во всех тестах, чтобы убрать дублирование повторяющегося кода для создания пользователя.
1. Добавлен [docker compose](https://docs.docker.com/compose/) конфигурация для запуска СУБД Postgres через [docker](https://ru.wikipedia.org/wiki/Docker)

resolves #77 